### PR TITLE
fix: http prefix duplication

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,12 @@ impl Client {
         target: String,
         api_key: String,
     ) -> Result<Client, Box<dyn std::error::Error>> {
-        let targetstr = "http://".to_owned() + &target;
+        let targetstr = if !target.starts_with("http://") {
+            "http://".to_owned() + &target
+        } else {
+            target
+        };
+
         let mut client = ApiClient::connect(targetstr.to_owned()).await?;
 
         // Set up the different streams


### PR DESCRIPTION
Adds an `if` block to handle the case where a user has already prefixed the client endpoint with `http://`