### PR TITLE
fix: remove unused crates, solve build error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,20 +10,15 @@ prost = "0.12"
 tonic = { version = "0.10", features = ["gzip", "prost"] }
 tokio = { version = "1.21.1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
-ethers = "2"
+ethers-core = "2.0.11"
 tokio-stream = "0.1"
 async-stream = "0.3"
-futures-core = "0.3"
-futures-util = "0.3"
 pin-project = "1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 serde_repr = "0.1"
 base64 = "0.13.1"
 hex = "0.4.3"
-chrono = "0.4.23"
-reth-primitives = { git = "https://github.com/chainbound/reth", branch = "patch/fiber" }
-reth-rlp = { package = "alloy-rlp", version = "0.3" }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,4 +1,4 @@
-use ethers::types::{Address, Bytes, U256};
+use ethers_core::types::{Address, Bytes, U256};
 use hex;
 use serde::Serialize;
 use serde_repr::Serialize_repr;


### PR DESCRIPTION
Build error:

```
error[E0599]: no function or associated item named `from_naive_utc_and_offset` found for struct `chrono::DateTime` in the current scope
   --> /Users/nico/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ethers-etherscan-2.0.12/src/stats.rs:106:25
    |
106 |     Ok(DateTime::<Utc>::from_naive_utc_and_offset(naive_date.and_time(naive_time), Utc))
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `DateTime<Utc>`

```

Solved by just importing `ethers_core` instead of the entire `ethers` package which included the build issue somewhere. 

Also removed a few unused dependencies.