### PR TITLE
fix: use specific alloy commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["Chainbound <admin@chainbound.io>"]
 
 [dependencies]
 # types & decoding
-alloy-rpc-engine-types = { git = "https://github.com/alloy-rs/alloy", features = ["ssz"] }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", features = ["ssz"] }
+alloy-rpc-engine-types = { git = "https://github.com/alloy-rs/alloy", features = ["ssz"], rev = "e127fed" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", features = ["ssz"], rev = "e127fed" }
 alloy-rlp = { git = "https://github.com/alloy-rs/rlp" }
 ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus" }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v0.1.0-alpha.17" }


### PR DESCRIPTION
currently the build is breaking due to an alloy update. This will use the commit before that update until the update is incorporated into fiber