### PR TITLE
chore: updated dependencies (reth, alloy) + version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
 name = "fiber"
-version = "0.7.2"
+version = "0.7.4"
 edition = "2021"
 license = "MIT"
 authors = ["Chainbound <admin@chainbound.io>"]
 
 [dependencies]
-# types & decoding
-alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", features = [
-    "ssz",
-], rev = "7d5e42f" }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", features = [
-    "ssz",
-], rev = "7d5e42f" }
+# alloy
+alloy-rpc-types-engine = { version = "0.1.3", features = ["ssz"] }
+alloy-rpc-types = { version = "0.1.3", features = ["ssz"] }
 alloy-rlp = "0.3"
+
+# reth
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.0.0", default-features = false, features = ["std", "c-kzg"] }
+
+# ethereum
 ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "cf3c404" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v0.2.0-beta.6", default-features = false, features = [
-    "c-kzg",
-] }
-serde = { version = "1.0", features = ["derive", "rc"] }
 ethereum_ssz = "0.5.3"
+
+# serialization
+serde = { version = "1.0", features = ["derive", "rc"] }
 base64 = "0.13.1"
 serde_json = "1.0"
 serde_repr = "0.1"

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -3,8 +3,8 @@ use std::{process::Command, str::FromStr};
 use ethereum_consensus::{ssz::prelude::deserialize, types::mainnet::SignedBeaconBlock};
 use fiber::Client;
 use reth_primitives::{
-    AccessList, Address, Signature, Transaction, TransactionKind, TransactionSigned, TxEip1559,
-    TxHash, TxType, B256, U256,
+    AccessList, Address, Signature, Transaction, TransactionSigned, TxEip1559, TxHash, TxKind,
+    TxType, B256, U256,
 };
 use tokio_stream::StreamExt;
 
@@ -29,10 +29,17 @@ async fn test_new_type_3_transactions() {
 
     let mut sub = client.subscribe_new_transactions(None).await;
 
+    let mut i = 0;
     while let Some(tx) = sub.next().await {
         if tx.tx_type() == TxType::Eip4844 {
             println!("blob tx: {}", tx.hash());
             println!("blob hashes: {:?}", tx.blob_versioned_hashes());
+
+            i += 1;
+
+            if i > 3 {
+                break;
+            }
         }
     }
 }
@@ -160,7 +167,7 @@ async fn test_send_tx() {
         chain_id: 1,
             nonce: 0x42,
             gas_limit: 44386,
-            to: TransactionKind::Call( Address::from_str("0x6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").unwrap()),
+            to: TxKind::Call( Address::from_str("0x6069a6c32cf691f5982febae4faf8a6f3ab2f0f6").unwrap()),
             value: U256::from(0),
             input:  hex::decode("a22cb4650000000000000000000000005eee75727d804a2b13038928d36f8b188945a57a0000000000000000000000000000000000000000000000000000000000000000").unwrap().into(),
             max_fee_per_gas: 0x4a817c800,


### PR DESCRIPTION
Updated package to v0.7.4, using Reth v1.0.0 release tag.